### PR TITLE
fix: RuntimeError on dict iteration (Python 3.12+) and pkg_resources removed in setuptools 81+

### DIFF
--- a/omegaconf/_impl.py
+++ b/omegaconf/_impl.py
@@ -58,7 +58,7 @@ def _resolve(cfg: Node, escape_interpolation_strings: bool) -> Node:
             cfg._set_value(val)
 
     if isinstance(cfg, DictConfig):
-        for k in cfg.keys():
+        for k in list(cfg.keys()):  # snapshot keys; a resolver may structurally modify the dict
             _resolve_container_value(cfg, k, escape_interpolation_strings)
 
     elif isinstance(cfg, ListConfig):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ OmegaConf setup
 """
 import pathlib
 
-import pkg_resources
 import setuptools
 
 from build_helpers.build_helpers import (
@@ -22,11 +21,11 @@ from build_helpers.build_helpers import (
     find_version,
 )
 
-with pathlib.Path("requirements/base.txt").open() as requirements_txt:
-    install_requires = [
-        str(requirement)
-        for requirement in pkg_resources.parse_requirements(requirements_txt)
-    ]
+install_requires = [
+    line.strip()
+    for line in pathlib.Path("requirements/base.txt").read_text().splitlines()
+    if line.strip() and not line.strip().startswith("#")
+]
 
 
 with open("README.md", "r") as fh:

--- a/tests/test_omegaconf.py
+++ b/tests/test_omegaconf.py
@@ -571,7 +571,7 @@ def test_resolve_does_not_raise_when_resolver_adds_keys() -> None:
             "z": 3,
         }
     finally:
-        OmegaConf.clear_resolvers()
+        OmegaConf.clear_resolver("merge_test")
 
 
 @mark.parametrize(

--- a/tests/test_omegaconf.py
+++ b/tests/test_omegaconf.py
@@ -545,6 +545,35 @@ def test_resolve_invalid_input() -> None:
         OmegaConf.resolve("aaa")  # type: ignore
 
 
+def test_resolve_does_not_raise_when_resolver_adds_keys() -> None:
+    """Regression test: OmegaConf.resolve must not raise RuntimeError when a
+    custom resolver returns a DictConfig that causes new keys to be written into
+    the parent dict during iteration (Python 3.12+ raises
+    'RuntimeError: dictionary changed size during iteration' without the fix).
+    """
+    OmegaConf.register_new_resolver(
+        "merge_test",
+        lambda a, b: OmegaConf.merge(a, b),
+        replace=True,
+    )
+    try:
+        cfg = OmegaConf.create(
+            {
+                "base": {"x": 1, "y": 2},
+                "extra": {"z": 3},
+                "merged": "${merge_test:${base},${extra}}",
+            }
+        )
+        OmegaConf.resolve(cfg)
+        assert OmegaConf.to_container(cfg, resolve=False)["merged"] == {
+            "x": 1,
+            "y": 2,
+            "z": 3,
+        }
+    finally:
+        OmegaConf.clear_resolvers()
+
+
 @mark.parametrize(
     "cfg, expected",
     [


### PR DESCRIPTION
## Summary

Two bugs in `kapicorp/omegaconf` prevent the omegaconf inventory backend from working on Python 3.12+ with modern tooling (setuptools 81+). Both are fixed in this single commit.

Tracking issue in kapicorp/kapitan: https://github.com/kapicorp/kapitan/issues/1416

---

## Fix 1: `RuntimeError: dictionary changed size during iteration` on Python 3.12+

**File:** `omegaconf/_impl.py`

### Root cause

In `_resolve()`, the loop iterates a live dict view:

```python
for k in cfg.keys():   # live view
```

When a resolver (e.g. `${merge:...}`) returns a `DictConfig`, `_resolve_container_value` promotes the `ValueNode` to a `DictConfig` in-place, which structurally modifies the dict mid-iteration. Python 3.6–3.11 silently tolerated this. Python 3.12+ raises:

```
RuntimeError: dictionary changed size during iteration
```

This also affects kapitan's own `write_to_key` resolver which calls `OmegaConf.update(_root_, ...)` mid-iteration.

### Change

```python
- for k in cfg.keys():
+ for k in list(cfg.keys()):  # snapshot keys; a resolver may structurally modify the dict
```

Also filed upstream: https://github.com/omry/omegaconf/issues/1239 / https://github.com/omry/omegaconf/pull/1240

---

## Fix 2: `ModuleNotFoundError: No module named 'pkg_resources'`

**File:** `setup.py`

### Root cause

`setup.py` imports `pkg_resources` at the top level to parse the requirements file. `pkg_resources` was bundled inside `setuptools` through version 80. **`setuptools` 81+ removed it** as a top-level importable module, so any install from git source with a modern environment fails at build time.

### Change

Replace `pkg_resources.parse_requirements()` with plain file parsing (the requirements file is simple enough that no extra parsing is needed):

```python
install_requires = [
    line.strip()
    for line in pathlib.Path("requirements/base.txt").read_text().splitlines()
    if line.strip() and not line.strip().startswith("#")
]
```

---

## Tests

Added `test_resolve_does_not_raise_when_resolver_adds_keys` in `tests/test_omegaconf.py` as a regression test for Fix 1.
